### PR TITLE
docs: fix simple typo, seperate -> separate

### DIFF
--- a/haml/parse.py
+++ b/haml/parse.py
@@ -143,7 +143,7 @@ class Parser(object):
             
             if line:
                 
-                # We track the inter-line depth seperate from the intra-line depth
+                # We track the inter-line depth separate from the intra-line depth
                 # so that indentation due to whitespace always results in more
                 # depth in the graph than many nested nodes from a single line.
                 inter_depth = len(raw_line) - len(line)


### PR DESCRIPTION
There is a small typo in haml/parse.py.

Should read `separate` rather than `seperate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md